### PR TITLE
Use correct base type for GetPointOutput type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -25,7 +25,7 @@ export interface GetPointInput {
   GeoPoint: GeoPoint;
   GetItemInput: DynamoDB.GetItemInput;
 }
-export interface GetPointOutput extends GeoQueryOutput {
+export interface GetPointOutput extends DynamoDB.GetItemOutput {
 }
 export interface PutPointInput {
   RangeKeyValue: DynamoDB.AttributeValue;


### PR DESCRIPTION
`GetPointOutput` was inheriting from `GeoQueryOutput` which in turn inherits from `DynamoDB.QueryOutput`.

The signature of this type contains an `Items` key, which doesn't properly match up with what the `DynamoDB.getItem` function returns.

I have changed the base type for `GetPointOutput` to `DynamoDB.GetItemOutput` to correct this issue.
