### PR TITLE
make aws-sdk a dev dependency so lambda zips can be smaller

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,10 +16,10 @@
   "dependencies": {
     "@types/decimal.js": "^0.0.30",
     "@types/long": ">=3",
-    "aws-sdk": "^2.176.0",
     "nodes2ts": "^1.1.10"
   },
   "devDependencies": {
+    "aws-sdk": "^2.176.0",
     "@types/chai": "^4.0.0",
     "@types/mocha": "^2.2.41",
     "@types/node": "^7.0.27",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "nodes2ts": "^1.1.10"
   },
   "devDependencies": {
-    "aws-sdk": "^2.176.0",
     "@types/chai": "^4.0.0",
     "@types/mocha": "^2.2.41",
     "@types/node": "^7.0.27",
@@ -27,5 +26,8 @@
     "mocha": "^3.3.0",
     "ts-node": "^3.0.2",
     "typescript": "^2.3.4"
+  },
+  "peerDependencies": {
+    "aws-sdk": "^2.176.0"
   }
 }


### PR DESCRIPTION
Hi, thank you for the nice package. Would it be possible to change the aws-sdk to a dev dependency? The lambda environment already has the aws-sdk available.

Cheers...