### PR TITLE
Make the default GeoJSON output standard-compliant

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,13 @@ This fork allows you to choose between [awslabs/dynamodb-geo][dynamodb-geo] comp
 
 Note that this value should match the state of your existing data - if you change it you must update your database manually, or you'll end up with ambiguously mixed data.
 
+#### geoJsonPointType: "Point" | "POINT" = "Point"
+The value of the `type` attribute in recorded GeoJSON points. Should normally be `"Point"`, which is standards compliant.
+
+Use `"POINT"` for compatibility with [awslabs/dynamodb-geo][dynamodb-geo].
+
+This setting is only relevant for writes. This library doesn't inspect or set this value when reading/querying.
+
 #### geohashAttributeName: string = "geohash"
 The name of the attribute storing the full 64-bit geohash. Its value is auto-generated based on item coordinates.
 

--- a/src/GeoDataManagerConfiguration.ts
+++ b/src/GeoDataManagerConfiguration.ts
@@ -48,13 +48,13 @@ export class GeoDataManagerConfiguration {
   /**
    * The value of the 'type' attribute in recorded GeoJSON points. Should normally be 'Point', which is standards compliant.
    *
-   * Use 'POINT' [lat, lon] for compatibility with the Java library https://github.com/awslabs/dynamodb-geo
+   * Use 'POINT' for compatibility with the Java library https://github.com/awslabs/dynamodb-geo
    *
-   * This setting is only relevant for writes. This library doesn't inspect this value when reading/querying.
+   * This setting is only relevant for writes. This library doesn't inspect or set this value when reading/querying.
    *
-   * @type {boolean}
+   * @type {string}
    */
-  geoJsonPointType: string = 'Point';
+  geoJsonPointType: 'Point' | 'POINT' = 'Point';
 
   dynamoDBClient: DynamoDB;
 

--- a/src/GeoDataManagerConfiguration.ts
+++ b/src/GeoDataManagerConfiguration.ts
@@ -45,6 +45,17 @@ export class GeoDataManagerConfiguration {
    */
   longitudeFirst: boolean = true;
 
+  /**
+   * The value of the 'type' attribute in recorded GeoJSON points. Should normally be 'Point', which is standards compliant.
+   *
+   * Use 'POINT' [lat, lon] for compatibility with the Java library https://github.com/awslabs/dynamodb-geo
+   *
+   * This setting is only relevant for writes. This library doesn't inspect this value when reading/querying.
+   *
+   * @type {boolean}
+   */
+  geoJsonPointType: string = 'Point';
+
   dynamoDBClient: DynamoDB;
 
   S2RegionCoverer: typeof S2RegionCoverer;

--- a/src/dynamodb/DynamoDBManager.ts
+++ b/src/dynamodb/DynamoDBManager.ts
@@ -119,7 +119,7 @@ export class DynamoDBManager {
     putItemInput.Item[this.config.geohashAttributeName] = { N: geohash.toString(10) };
     putItemInput.Item[this.config.geoJsonAttributeName] = {
       S: JSON.stringify({
-        type: 'POINT',
+        type: this.config.geoJsonPointType,
         coordinates: (this.config.longitudeFirst ?
           [putPointInput.GeoPoint.longitude, putPointInput.GeoPoint.latitude] :
           [putPointInput.GeoPoint.latitude, putPointInput.GeoPoint.longitude])
@@ -147,7 +147,7 @@ export class DynamoDBManager {
       putRequest.Item[this.config.geohashAttributeName] = { N: geohash.toString(10) };
       putRequest.Item[this.config.geoJsonAttributeName] = {
         S: JSON.stringify({
-          type: 'POINT',
+          type: this.config.geoJsonPointType,
           coordinates: (this.config.longitudeFirst ?
             [putPointInput.GeoPoint.longitude, putPointInput.GeoPoint.latitude] :
             [putPointInput.GeoPoint.latitude, putPointInput.GeoPoint.longitude])

--- a/test/dynamodb/DynamoDBManager.ts
+++ b/test/dynamodb/DynamoDBManager.ts
@@ -42,7 +42,7 @@ describe('DynamoDBManager.putPoint', () => {
         expect(args).to.deep.equal({
             TableName: 'MyTable',
             Item: {
-              geoJson: { S: "{\"type\":\"POINT\",\"coordinates\":[-0.13,51.51]}" },
+              geoJson: { S: "{\"type\":\"Point\",\"coordinates\":[-0.13,51.51]}" },
               geohash: { N: "5221366118452580119" },
               hashKey: { N: "52" },
               rangeKey: { S: "1234" },

--- a/test/integration/example.ts
+++ b/test/integration/example.ts
@@ -94,7 +94,7 @@ describe('Example', function () {
                 country: { S: 'United Kingdom' },
                 capital: { S: 'London' },
                 hashKey: { N: '522' },
-                geoJson: { S: '{"type":"POINT","coordinates":[-0.13,51.51]}' },
+                geoJson: { S: '{"type":"Point","coordinates":[-0.13,51.51]}' },
                 geohash: { N: '5221366118452580119' }
             }])
         });


### PR DESCRIPTION
Make the default GeoJSON output standard-compliant, but configurable for compatibility

Fixes https://github.com/rh389/dynamodb-geo.js/issues/12