### PR TITLE
Use isLong utility function instead of instanceof to check if provide value is of type Long.

### DIFF
--- a/src/model/GeohashRange.ts
+++ b/src/model/GeohashRange.ts
@@ -6,9 +6,9 @@ export class GeohashRange {
   rangeMin: Long;
   rangeMax: Long;
 
-  constructor(min: Long, max: Long) {
-    this.rangeMin = min instanceof Long ? min : Long.fromNumber(min);
-    this.rangeMax = max instanceof Long ? max : Long.fromNumber(max);
+  constructor(min: Long | number, max: Long | number) {
+    this.rangeMin = Long.isLong(min) ? <Long>min : Long.fromNumber(<number>min);
+    this.rangeMax = Long.isLong(max) ? <Long>max : Long.fromNumber(<number>max);
   }
 
   public tryMerge(range: GeohashRange): boolean {


### PR DESCRIPTION
There is a slight problem with the current implementation if several versions of long.js package exist within the same project. 

The references of constructors don't match, so `something instanceof Long` won't work.

This PR simply changes the way the type of the variables checked. Instead of using **instanceof**, it uses long.js utility function **isLong** 
