### PR TITLE
Updating circle.yml to use jobs and workflows

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,7 @@ containerInfo:
   - image: rh389/node-base
   - image: deangiberson/aws-dynamodb-local
 
-stages:
+jobs:
   build:
     workDir: ~/workspace
     steps:
@@ -18,3 +18,10 @@ stages:
           key: v1-yarn-{{ checksum "yarn.lock" }}
           paths:
             - ~/workspace/node_modules
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - build
+


### PR DESCRIPTION
@rh389 - The [build seems to be failing](https://app.circleci.com/pipelines/github/rh389/dynamodb-geo.js/5/workflows/a79acb40-6ba3-44b3-a630-1f636b13aa2c/jobs/64) on circleci due to invalid config. I'm guessing CircleCI's v2, that introduced workflows, deprecates the `stages` config. I downloaded the circleci CLI and validated the config and ran the build locally. Everything seemed to work, except that locally the `restore_cache` and `save_cache` commands failed. I assume this is a quirk of running locally. The build still worked despite the cache issue, and it appears the only effect is that package dependencies aren't cached.

```
$ circleci config validate circle.yml
Config file at circle.yml is valid.
```

**snippet from local execution:**
```
====>> yarn install && yarn test
  #!/bin/sh
yarn install && yarn test
yarn install v1.6.0
(node:49) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Building fresh packages...
$ tsc -d
Done in 10.92s.
yarn run v1.6.0
(node:85) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
$ mocha --require ts-node/register test/**/*.ts


(node:112) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
  DynamoDBManager.deletePoint
    ✓ calls deleteItem with the correct arguments 

  DynamoDBManager.putPoint
    ✓ calls putItem with the correct arguments 

  Example
Loading sample data from capitals.json
Writing batch 1/3
Writing batch 2/3
Writing batch 3/3
Finished loading
    ✓ queryRadius (499ms)

  Appropriate hash key lengths
    ✓ 10m radius (182ms)
    ✓ 1km radius (110ms)
    ✓ 10km radius (139ms)
    ✓ 50km radius (99ms)
    ✓ 100km radius (136ms)
    ✓ 1000km radius (158ms)

  GeohashRange.trySplit
    ✓ returns the same range when nothing needs splitting
    ✓ splits correctly on the given digit

  S2Manager
    ✓ generateGeoHash
    ✓ generateHashKey


  13 passing (6s)

Done in 13.57s.

```